### PR TITLE
feat: Validation Image File Size on PBI 24 Create New Team-Frontend

### DIFF
--- a/src/components/forms/fileInput/index.js
+++ b/src/components/forms/fileInput/index.js
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { FormControl, FormLabel, Box, InputGroup, InputLeftElement, Icon, Flex } from '@chakra-ui/react';
+import { FormControl, FormLabel, FormErrorMessage, Box, InputGroup, InputLeftElement, Icon, Flex } from '@chakra-ui/react';
 import { useController } from "react-hook-form";
 import { FiFile } from 'react-icons/fi'
 import { Input } from '@chakra-ui/input';
@@ -9,7 +9,7 @@ import logo from '../../../assets/icons/logo-monapi.svg';
 
 const FileInput = (props) => {
   const { id, errors, rules, accept, w, multiple, title, control,
-          placeholder, textChange, hasLabel = true } = props;
+          placeholder, textChange, hasLabel = true, description } = props;
 
   const [img, setImg] = useState(logo)
 
@@ -66,9 +66,11 @@ const FileInput = (props) => {
                     id={id}
                   ></Input>
                 </InputGroup>
+                <p style={{paddingTop:'10px'}}>{description}</p>
               </Box>
             </Flex>
           </Flex>
+          <FormErrorMessage>{errors[id] && errors[id].message}</FormErrorMessage>
         </FormControl>
       </Box>
   );

--- a/src/routes/createTeam/index.js
+++ b/src/routes/createTeam/index.js
@@ -104,7 +104,6 @@ const CreateTeam = () => {
                                             if (file && ((file.size/(1024 * 1024)) > 10)) {
                                                 return 'Please choose image that the file size less than or equal to 10MB'
                                             }
-                                            return true
                                         }
                                     }}
                                 />               

--- a/src/routes/createTeam/index.js
+++ b/src/routes/createTeam/index.js
@@ -102,7 +102,7 @@ const CreateTeam = () => {
                                     rules={{ 
                                         validate: (file) => {
                                             if (file && ((file.size/(1024 * 1024)) > 10)) {
-                                                return 'Please choose image that the file size below or equal 10MB'
+                                                return 'Please choose image that the file size less than or equal to 10MB'
                                             }
                                             return true
                                         }

--- a/src/routes/createTeam/index.js
+++ b/src/routes/createTeam/index.js
@@ -98,6 +98,15 @@ const CreateTeam = () => {
                                     placeholder='Select Image'
                                     textChange='Change Image'
                                     register={register}
+                                    description='Maximum file size is 10MB'
+                                    rules={{ 
+                                        validate: (file) => {
+                                            if (file && ((file.size/(1024 * 1024)) > 10)) {
+                                                return 'Please choose image that the file size below or equal 10MB'
+                                            }
+                                            return true
+                                        }
+                                    }}
                                 />               
                         
                             <Box mb='10px' />

--- a/tests/routes/createTeam/createTeam.test.js
+++ b/tests/routes/createTeam/createTeam.test.js
@@ -81,6 +81,30 @@ describe('Test input', () => {
 		});		
 	});
 
+  test('When user upload image file size more than 10MB, then failed', async () => {
+		render(<CreateTeam />);
+
+    const nameField = await screen.findByPlaceholderText('Insert Team Name');
+    userEvent.type(nameField, 'myteam')
+
+    global.URL.createObjectURL = jest.fn();
+
+    // create new file that have size more than 10MB, specificly 10MB + 1b
+    const imageFile = new File([new ArrayBuffer(1024 * 1024 * 10 + 1)], 'hello.png', { type: "image/png" });
+    
+    const fileField = await screen.findByPlaceholderText('Select Image');
+
+    // test file input can upload image file
+    userEvent.upload(fileField, imageFile)
+    
+		const Create = screen.getByText('Create');
+		userEvent.click(Create);
+
+		await waitFor(() => {
+      expect(screen.getByText("Please choose image that the file size below or equal 10MB"))
+		});		
+	});
+
   test('When user click Create button, then show spinner to loading', async () => {
 		let response = {
 			name: "myteam"

--- a/tests/routes/createTeam/createTeam.test.js
+++ b/tests/routes/createTeam/createTeam.test.js
@@ -101,7 +101,7 @@ describe('Test input', () => {
 		userEvent.click(Create);
 
 		await waitFor(() => {
-      expect(screen.getByText("Please choose image that the file size below or equal 10MB"))
+      expect(screen.getByText("Please choose image that the file size less than or equal to 10MB"))
 		});		
 	});
 


### PR DESCRIPTION
### Describe your changes
- Adding validation image file size that must less than or equal to 10MB

### Backlog name
[MON-96: Create new team frontend](https://monapi.atlassian.net/browse/MON-96)

### Acceptance criteria
- User can create new team by filling team name, description and team logo
- Team name is mandatory. Meanwhile team description and logo is optional
- Error is shown when team name is empty

### Checklist
- [x] I have performed a self-review of my code
- [x] Code successfully run on local
- [x] Feature / changes tested on local
- [x] No failing unit test
- [ ] Passed UAT Test
- [x] Sonarqube tested

### Example
![image](https://user-images.githubusercontent.com/77453015/203764387-9f465a7c-37e7-4746-80a8-2061b7562231.png)
