### PR TITLE
fix(chart): bug fix parse iso date in chart

### DIFF
--- a/src/components/chart/response_time_chart/index.js
+++ b/src/components/chart/response_time_chart/index.js
@@ -14,7 +14,7 @@ const ResponseTimeChart = ({response_time, stepSizeInSecond}) => {
   const parseISODateToChart = (isoDate) => {
     const date = new Date(isoDate);
     const year = date.getFullYear();
-    const month = date.getMonth();
+    const month = date.getMonth() + 1;
     const dt = date.getDate();
     const hour = date.getHours();
     const minute =date.getMinutes();

--- a/src/components/chart/success_rate_percentage_chart/index.js
+++ b/src/components/chart/success_rate_percentage_chart/index.js
@@ -21,7 +21,7 @@ const SuccessRatePercentageChart = ({success_rate, stepSizeInSecond}) => {
   const parseISODateToChart = (isoDate) => {
     const date = new Date(isoDate);
     const year = date.getFullYear();
-    const month = date.getMonth();
+    const month = date.getMonth() + 1;
     const dt = date.getDate();
     const hour = date.getHours();
     const minute = date.getMinutes();


### PR DESCRIPTION
### Describe your changes
Bug fix parse ISO date in chart because getMonth() return in zero-index (0-11)

### Backlog name

### Checklist
- [x] I have performed a self-review of my code
- [x] Code successfully run on local
- [x] Feature / changes tested on local
- [x] No failing unit test
- [ ] Passed UAT Test
- [x] Sonarqube tested 
- [ ] Required any changes to environment variable
